### PR TITLE
Creating intent with receiver when cancelling.

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -45,6 +45,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import de.appplant.cordova.plugin.localnotification.TriggerReceiver;
+
 import static android.app.AlarmManager.RTC;
 import static android.app.AlarmManager.RTC_WAKEUP;
 import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
@@ -88,6 +90,9 @@ public final class Notification {
 
     // Builder with full configuration
     private final NotificationCompat.Builder builder;
+
+    // Receiver to handle the trigger event
+    private Class<?> receiver = TriggerReceiver.class;
 
     /**
      * Constructor
@@ -176,6 +181,8 @@ public final class Notification {
         List<Pair<Date, Intent>> intents = new ArrayList<Pair<Date, Intent>>();
         Set<String> ids                  = new ArraySet<String>();
         AlarmManager mgr                 = getAlarmMgr();
+
+        this.receiver = receiver;
 
         cancelScheduledAlarms();
 
@@ -302,7 +309,8 @@ public final class Notification {
             return;
 
         for (String action : actions) {
-            Intent intent = new Intent(action);
+            Intent intent = new Intent(context, this.receiver)
+                    .setAction(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
                     context, 0, intent, 0);
@@ -336,6 +344,8 @@ public final class Notification {
     void update (JSONObject updates, Class<?> receiver) {
         mergeJSONObjects(updates);
         persist(null);
+
+        this.receiver = receiver;
 
         if (getType() != Type.TRIGGERED)
             return;


### PR DESCRIPTION
Fixes "too many alarms (500)" issue on Samsung devices after cancelling and
scheduling notifications, by creating the same Intent when cancelling an
existing notification, just like the one that was used to create the notification.
This clears both the PendingIntent and the scheduled Alarm.

Uses TriggerReceiver.class as the default receiver.

Use the "adb shell dumpsys alarm" command to confirm that the number of
alarms don't increase from your app, when cancelling and scheduling
notifications. Previously the Alarm remained in the alarm list when cancelling.